### PR TITLE
Added chapter range support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,31 +10,35 @@ composer require bkuhl/scripture-ranges
 
 ## Creating Ranges (Recommended)
 
-Use the `ScriptureRangeBuilder` for a clean, readable API:
+Use the `ScriptureRangeBuilder` with multiple syntax options:
 
 ```php
 use BKuhl\ScriptureRanges\ScriptureRangeBuilder;
+use BKuhl\ScriptureRanges\ChapterRange;
 
-// Create multiple ranges with exclusions
 $builder = new ScriptureRangeBuilder([$myBookResolver]);
+
+// 1. Traditional parameter syntax
 $collection = $builder
     ->with(BookEnum::JOHN, chapter: 3, verse: 1, toVerse: 36)
     ->without(BookEnum::JOHN, chapter: 3, verse: 16, toVerse: 17)
-    ->without(BookEnum::JOHN, chapter: 3, verse: 22)
-    ->with('Matthew', chapter: 5, verse: 1, toVerse: 48)     // String book
-    ->without('Matthew', chapter: 5, verse: 10, toVerse: 15)
-    ->with(42, chapter: 2, verse: 8, toVerse: 20)           // Book by position
-    ->build(); // Returns RangeCollection
-
-// Single range with defaults
-$collection = $builder
-    ->with('John', chapter: 3)                              // Verse 1 to end of chapter
     ->build();
 
-// Specific verse range
+// 2. Chapter range syntax
 $collection = $builder
-    ->with($johnBook, chapter: 3, verse: 16, toVerse: 17)
+    ->with(BookEnum::JOHN, chapter: 3, chapterEnd: 5)      // Multiple chapters
+    ->with('Matthew', chapter: 5, verse: 1, toVerse: 48)   // Mixed with verse ranges
     ->build();
+
+// 3. ChapterRange object syntax (cleanest for chapter ranges!)
+$collection = $builder
+    ->with(BookEnum::JOHN, ChapterRange::range(3, 5))      // Chapters 3-5
+    ->with('Matthew', chapter: 5, verse: 1, toVerse: 48)   // Use traditional syntax for verses
+    ->without(BookEnum::JOHN, chapter: 3, verse: 16)       // Use traditional syntax for single verses
+    ->build();
+
+// ChapterRange factory method:
+ChapterRange::range(3, 5)             // Chapters 3-5 (full chapters only)
 ```
 
 ## Book Resolvers
@@ -99,4 +103,25 @@ $json = $collection->toJson();
 //   "id": "morning-plan-456", 
 //   "ranges": [...]
 // }
+```
+
+## ChapterRange Quick Example
+
+For working with chapter ranges, use the `ChapterRange` class:
+
+```php
+use BKuhl\ScriptureRanges\ChapterRange;
+
+// Create a chapter range
+$range = ChapterRange::range(3, 5);  // Chapters 3-5
+
+// Get start and end chapters
+$start = $range->getStart();  // 3
+$end = $range->getEnd();      // 5
+
+// Use with ScriptureRangeBuilder
+$collection = $builder
+    ->with($book, ChapterRange::range(1, 3))    // Full chapters 1-3
+    ->with($book, chapter: 4, verse: 1, toVerse: 10)  // Specific verses
+    ->build();
 ```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $collection = $builder
     ->build();
 
 // ChapterRange factory method:
-ChapterRange::range(3, 5)             // Chapters 3-5 (full chapters only)
+ChapterRange::range(3, 5)             // Chapters 3-5 (full chapters)
 ```
 
 ## Book Resolvers

--- a/src/ChapterRange.php
+++ b/src/ChapterRange.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BKuhl\ScriptureRanges;
+
+class ChapterRange
+{
+    public function __construct(
+        private readonly int $startChapter,
+        private readonly int $endChapter
+    ) {
+        if ($startChapter > $endChapter) {
+            throw new \InvalidArgumentException('Start chapter cannot be greater than end chapter');
+        }
+    }
+
+    /**
+     * Create a range spanning multiple chapters
+     */
+    public static function range(int $startChapter, int $endChapter): self
+    {
+        return new self($startChapter, $endChapter);
+    }
+
+    public function getStart(): int
+    {
+        return $this->startChapter;
+    }
+
+    public function getEnd(): int
+    {
+        return $this->endChapter;
+    }
+} 

--- a/src/ScriptureRangeBuilder.php
+++ b/src/ScriptureRangeBuilder.php
@@ -42,18 +42,26 @@ class ScriptureRangeBuilder
     ): self {
         $bookInterface = $this->resolveBook($book);
         
-        // Handle ChapterRange object
+        // Determine chapter range
         if ($chapter instanceof ChapterRange) {
             $startChapter = $chapter->getStart();
             $endChapter = $chapter->getEnd();
-            $fromVerse = 1;
-            $toVerse = $bookInterface->chapterVerseCount($endChapter);
         } else {
-            // Handle traditional parameter syntax
             $startChapter = $chapter;
             $endChapter = $chapterEnd ?? $chapter;
-            $fromVerse = $this->resolveVerse($verse) ?? 1;
-            $toVerse = $this->resolveVerse($toVerse) ?? $bookInterface->chapterVerseCount($endChapter);
+        }
+        
+        // Resolve verse parameters
+        $fromVerse = $this->resolveVerse($verse) ?? 1;
+        $resolvedToVerse = $this->resolveVerse($toVerse);
+        
+        // Determine ending verse based on context
+        if ($resolvedToVerse !== null) {
+            $toVerse = $resolvedToVerse;
+        } else {
+            // Default to end of the target chapter
+            $targetChapter = ($chapter instanceof ChapterRange) ? $endChapter : $endChapter;
+            $toVerse = $bookInterface->chapterVerseCount($targetChapter);
         }
 
         $this->currentRange = new ScriptureRange(
@@ -82,18 +90,28 @@ class ScriptureRangeBuilder
 
         $bookInterface = $this->resolveBook($book);
         
-        // Handle ChapterRange object
+        // Determine chapter range
         if ($chapter instanceof ChapterRange) {
             $startChapter = $chapter->getStart();
             $endChapter = $chapter->getEnd();
-            $fromVerse = 1;
-            $toVerse = $bookInterface->chapterVerseCount($endChapter);
         } else {
-            // Handle traditional parameter syntax
             $startChapter = $chapter;
             $endChapter = $chapterEnd ?? $chapter;
-            $fromVerse = $this->resolveVerse($verse) ?? 1;
-            $toVerse = $this->resolveVerse($toVerse) ?? $fromVerse;
+        }
+        
+        // Resolve verse parameters
+        $fromVerse = $this->resolveVerse($verse) ?? 1;
+        $resolvedToVerse = $this->resolveVerse($toVerse);
+        
+        // Determine ending verse based on context
+        if ($resolvedToVerse !== null) {
+            $toVerse = $resolvedToVerse;
+        } else {
+            // For exclusions, default to end of range or single verse
+            $targetChapter = ($chapter instanceof ChapterRange) ? $endChapter : $endChapter;
+            $toVerse = ($chapter instanceof ChapterRange) 
+                ? $bookInterface->chapterVerseCount($targetChapter)
+                : $fromVerse; // For traditional syntax, default to single verse exclusion
         }
 
         // Verify exclusion is in same book as current range

--- a/tests/ChapterRangeTest.php
+++ b/tests/ChapterRangeTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BKuhl\ScriptureRanges\Tests;
+
+use BKuhl\ScriptureRanges\ChapterRange;
+use PHPUnit\Framework\TestCase;
+
+class ChapterRangeTest extends TestCase
+{
+    public function testConstructorWithValidRange(): void
+    {
+        $range = new ChapterRange(3, 5);
+        
+        $this->assertEquals(3, $range->getStart());
+        $this->assertEquals(5, $range->getEnd());
+    }
+
+    public function testConstructorWithSameStartAndEnd(): void
+    {
+        $range = new ChapterRange(3, 3);
+        
+        $this->assertEquals(3, $range->getStart());
+        $this->assertEquals(3, $range->getEnd());
+    }
+
+    public function testConstructorThrowsExceptionWhenStartGreaterThanEnd(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Start chapter cannot be greater than end chapter');
+        
+        new ChapterRange(5, 3);
+    }
+
+    public function testRangeFactoryMethod(): void
+    {
+        $range = ChapterRange::range(2, 7);
+        
+        $this->assertInstanceOf(ChapterRange::class, $range);
+        $this->assertEquals(2, $range->getStart());
+        $this->assertEquals(7, $range->getEnd());
+    }
+
+    public function testRangeFactoryMethodWithSameStartAndEnd(): void
+    {
+        $range = ChapterRange::range(4, 4);
+        
+        $this->assertEquals(4, $range->getStart());
+        $this->assertEquals(4, $range->getEnd());
+    }
+
+    public function testRangeFactoryMethodThrowsExceptionWhenStartGreaterThanEnd(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Start chapter cannot be greater than end chapter');
+        
+        ChapterRange::range(8, 3);
+    }
+
+    public function testGetStart(): void
+    {
+        $range = new ChapterRange(1, 10);
+        
+        $this->assertEquals(1, $range->getStart());
+    }
+
+    public function testGetEnd(): void
+    {
+        $range = new ChapterRange(1, 10);
+        
+        $this->assertEquals(10, $range->getEnd());
+    }
+
+    public function testGettersWithSingleChapter(): void
+    {
+        $range = ChapterRange::range(5, 5);
+        
+        $this->assertEquals(5, $range->getStart());
+        $this->assertEquals(5, $range->getEnd());
+    }
+
+    public function testPrivatePropertiesAccessibleViaGetters(): void
+    {
+        $range = new ChapterRange(2, 8);
+        
+        // Properties should be accessible via getters
+        $this->assertEquals(2, $range->getStart());
+        $this->assertEquals(8, $range->getEnd());
+        
+        // This test verifies the getter methods work correctly
+        // The private readonly nature is enforced by PHP itself
+    }
+
+    public function testMultipleInstancesAreIndependent(): void
+    {
+        $range1 = ChapterRange::range(1, 3);
+        $range2 = ChapterRange::range(5, 7);
+        
+        $this->assertEquals(1, $range1->getStart());
+        $this->assertEquals(3, $range1->getEnd());
+        
+        $this->assertEquals(5, $range2->getStart());
+        $this->assertEquals(7, $range2->getEnd());
+        
+        // Verify they don't affect each other
+        $this->assertNotEquals($range1->getStart(), $range2->getStart());
+        $this->assertNotEquals($range1->getEnd(), $range2->getEnd());
+    }
+
+    public function testChapterRangeWithMinimumValues(): void
+    {
+        $range = ChapterRange::range(1, 1);
+        
+        $this->assertEquals(1, $range->getStart());
+        $this->assertEquals(1, $range->getEnd());
+    }
+
+    public function testChapterRangeWithLargeValues(): void
+    {
+        $range = ChapterRange::range(100, 150);
+        
+        $this->assertEquals(100, $range->getStart());
+        $this->assertEquals(150, $range->getEnd());
+    }
+} 

--- a/tests/ChapterRangeTest.php
+++ b/tests/ChapterRangeTest.php
@@ -123,4 +123,6 @@ class ChapterRangeTest extends TestCase
         $this->assertEquals(100, $range->getStart());
         $this->assertEquals(150, $range->getEnd());
     }
+
+
 } 

--- a/tests/ScriptureRangeBuilderTest.php
+++ b/tests/ScriptureRangeBuilderTest.php
@@ -366,4 +366,221 @@ class ScriptureRangeBuilderTest extends TestCase
         $this->assertEquals(1, $range->startVerse());
         $this->assertEquals(36, $range->endVerse()); // Full chapter 3
     }
+
+    public function testChapterRangeWithVerseParameters(): void
+    {
+        $builder = new ScriptureRangeBuilder([new TestBookResolver()]);
+        $chapterRange = \BKuhl\ScriptureRanges\ChapterRange::range(3, 5);
+        
+        $collection = $builder
+            ->with('john', $chapterRange, verse: 10, toVerse: 25)
+            ->build();
+        
+        $ranges = $collection->getRanges();
+        $range = $ranges[0];
+        
+        $this->assertEquals(3, $range->startChapter());
+        $this->assertEquals(5, $range->endChapter());
+        $this->assertEquals(10, $range->startVerse()); // verse parameter used
+        $this->assertEquals(25, $range->endVerse());   // toVerse parameter used
+    }
+
+    public function testChapterRangeWithOnlyStartVerse(): void
+    {
+        $builder = new ScriptureRangeBuilder([new TestBookResolver()]);
+        $chapterRange = \BKuhl\ScriptureRanges\ChapterRange::range(3, 4);
+        
+        $collection = $builder
+            ->with('john', $chapterRange, verse: 5)
+            ->build();
+        
+        $ranges = $collection->getRanges();
+        $range = $ranges[0];
+        
+        $this->assertEquals(3, $range->startChapter());
+        $this->assertEquals(4, $range->endChapter());
+        $this->assertEquals(5, $range->startVerse());  // verse parameter used
+        $this->assertEquals(54, $range->endVerse());   // Default to end of last chapter (chapter 4 has 54 verses)
+    }
+
+    public function testChapterRangeWithOnlyEndVerse(): void
+    {
+        $builder = new ScriptureRangeBuilder([new TestBookResolver()]);
+        $chapterRange = \BKuhl\ScriptureRanges\ChapterRange::range(3, 3);
+        
+        $collection = $builder
+            ->with('john', $chapterRange, toVerse: 20)
+            ->build();
+        
+        $ranges = $collection->getRanges();
+        $range = $ranges[0];
+        
+        $this->assertEquals(3, $range->startChapter());
+        $this->assertEquals(3, $range->endChapter());
+        $this->assertEquals(1, $range->startVerse());   // Default to 1
+        $this->assertEquals(20, $range->endVerse());    // toVerse parameter used
+    }
+
+    public function testChapterRangeWithVerseParametersInExclusion(): void
+    {
+        $builder = new ScriptureRangeBuilder([new TestBookResolver()]);
+        $mainRange = \BKuhl\ScriptureRanges\ChapterRange::range(1, 5);
+        $exclusionRange = \BKuhl\ScriptureRanges\ChapterRange::range(3, 3);
+        
+        $collection = $builder
+            ->with('john', $mainRange)
+            ->without('john', $exclusionRange, verse: 10, toVerse: 20)
+            ->build();
+        
+        $ranges = $collection->getRanges();
+        $range = $ranges[0];
+        
+        // Should have one exclusion with specific verse range
+        $exclusions = $range->exclusions();
+        $this->assertCount(1, $exclusions);
+        $this->assertEquals(3, $exclusions[0]['startChapter']);
+        $this->assertEquals(3, $exclusions[0]['endChapter']);
+        $this->assertEquals(10, $exclusions[0]['startVerse']);  // verse parameter used
+        $this->assertEquals(20, $exclusions[0]['endVerse']);    // toVerse parameter used
+    }
+
+    public function testChapterRangeVerseAppliesToFirstChapter(): void
+    {
+        $builder = new ScriptureRangeBuilder([new TestBookResolver()]);
+        $chapterRange = \BKuhl\ScriptureRanges\ChapterRange::range(2, 4);
+        
+        $collection = $builder
+            ->with('john', $chapterRange, verse: 15)
+            ->build();
+        
+        $ranges = $collection->getRanges();
+        $range = $ranges[0];
+        
+        // Verify the range spans chapters 2-4
+        $this->assertEquals(2, $range->startChapter());
+        $this->assertEquals(4, $range->endChapter());
+        
+        // Starting verse (15) should apply to first chapter (2)
+        $this->assertEquals(15, $range->startVerse());
+        
+        // Should default to end of last chapter (4) - John chapter 4 has 54 verses
+        $this->assertEquals(54, $range->endVerse());
+    }
+
+    public function testChapterRangeToVerseAppliesToLastChapter(): void
+    {
+        $builder = new ScriptureRangeBuilder([new TestBookResolver()]);
+        $chapterRange = \BKuhl\ScriptureRanges\ChapterRange::range(2, 4);
+        
+        $collection = $builder
+            ->with('john', $chapterRange, toVerse: 30)
+            ->build();
+        
+        $ranges = $collection->getRanges();
+        $range = $ranges[0];
+        
+        // Verify the range spans chapters 2-4
+        $this->assertEquals(2, $range->startChapter());
+        $this->assertEquals(4, $range->endChapter());
+        
+        // Should default to verse 1 of first chapter (2)
+        $this->assertEquals(1, $range->startVerse());
+        
+        // Ending verse (30) should apply to last chapter (4)
+        $this->assertEquals(30, $range->endVerse());
+    }
+
+    public function testChapterRangeBothVerseParametersApplyToRespectiveChapters(): void
+    {
+        $builder = new ScriptureRangeBuilder([new TestBookResolver()]);
+        $chapterRange = \BKuhl\ScriptureRanges\ChapterRange::range(1, 3);
+        
+        $collection = $builder
+            ->with('john', $chapterRange, verse: 10, toVerse: 25)
+            ->build();
+        
+        $ranges = $collection->getRanges();
+        $range = $ranges[0];
+        
+        // Verify the range spans chapters 1-3
+        $this->assertEquals(1, $range->startChapter());
+        $this->assertEquals(3, $range->endChapter());
+        
+        // Starting verse (10) applies to first chapter (1)
+        $this->assertEquals(10, $range->startVerse());
+        
+        // Ending verse (25) applies to last chapter (3)
+        $this->assertEquals(25, $range->endVerse());
+    }
+
+    public function testChapterRangeDefaultsWithNoVerseParameters(): void
+    {
+        $builder = new ScriptureRangeBuilder([new TestBookResolver()]);
+        $chapterRange = \BKuhl\ScriptureRanges\ChapterRange::range(2, 5);
+        
+        $collection = $builder
+            ->with('john', $chapterRange)
+            ->build();
+        
+        $ranges = $collection->getRanges();
+        $range = $ranges[0];
+        
+        // Verify the range spans chapters 2-5
+        $this->assertEquals(2, $range->startChapter());
+        $this->assertEquals(5, $range->endChapter());
+        
+        // Should default to verse 1 of first chapter (2)
+        $this->assertEquals(1, $range->startVerse());
+        
+        // Should default to end of last chapter (5) - John chapter 5 has 47 verses
+        $this->assertEquals(47, $range->endVerse());
+    }
+
+    public function testChapterRangeSingleChapterWithVerseParameters(): void
+    {
+        $builder = new ScriptureRangeBuilder([new TestBookResolver()]);
+        $chapterRange = \BKuhl\ScriptureRanges\ChapterRange::range(3, 3);
+        
+        $collection = $builder
+            ->with('john', $chapterRange, verse: 16, toVerse: 17)
+            ->build();
+        
+        $ranges = $collection->getRanges();
+        $range = $ranges[0];
+        
+        // Single chapter range
+        $this->assertEquals(3, $range->startChapter());
+        $this->assertEquals(3, $range->endChapter());
+        
+        // Both verses apply to the same chapter (3)
+        $this->assertEquals(16, $range->startVerse());
+        $this->assertEquals(17, $range->endVerse());
+    }
+
+    public function testChapterRangeVersusTraditionalSyntaxBehaviorConsistency(): void
+    {
+        $builder1 = new ScriptureRangeBuilder([new TestBookResolver()]);
+        $builder2 = new ScriptureRangeBuilder([new TestBookResolver()]);
+        
+        // ChapterRange syntax
+        $chapterRange = \BKuhl\ScriptureRanges\ChapterRange::range(2, 4);
+        $collection1 = $builder1
+            ->with('john', $chapterRange, verse: 10, toVerse: 25)
+            ->build();
+        
+        // Traditional syntax
+        $collection2 = $builder2
+            ->with('john', chapter: 2, chapterEnd: 4, verse: 10, toVerse: 25)
+            ->build();
+        
+        $range1 = $collection1->getRanges()[0];
+        $range2 = $collection2->getRanges()[0];
+        
+        // Both should produce identical results
+        $this->assertEquals($range1->startChapter(), $range2->startChapter());
+        $this->assertEquals($range1->endChapter(), $range2->endChapter());
+        $this->assertEquals($range1->startVerse(), $range2->startVerse());
+        $this->assertEquals($range1->endVerse(), $range2->endVerse());
+        $this->assertEquals($range1->reference(), $range2->reference());
+    }
 }


### PR DESCRIPTION
### What's Changed

**New ChapterRange Class:**
- Added `ChapterRange` class for clean chapter range specification
- Simple API: `ChapterRange::range(startChapter, endChapter)` with `getStart()` and `getEnd()` methods
- Private readonly properties with constructor validation

**Enhanced ScriptureRangeBuilder:**
- Added support for `ChapterRange` objects in `with()` and `without()` methods
- Added `chapterEnd` parameter for traditional syntax: `->with($book, chapter: 3, chapterEnd: 5)`
- Refactored builder logic to eliminate code duplication and improve maintainability
- Chapter-specific verse scoping: `verse` applies to first chapter, `toVerse` applies to last chapter

**New Syntax Options:**
```php
// Traditional (still works)
$builder->with($book, chapter: 3, verse: 1, toVerse: 36);

// ChapterRange object (cleanest for full chapters)
$builder->with($book, ChapterRange::range(3, 5));

// ChapterRange with verse parameters
$builder->with($book, ChapterRange::range(3, 5), verse: 10, toVerse: 25);
```